### PR TITLE
cleanup, refactor, makefile update for debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ LIB            := $(BUILD_DIR)/libe3db.a
 CFLAGS         := -Wall -g
 LDFLAGS        :=
 
-# switch above CFLAGS and LDFLAGS for below to debug memory access issues
-# CFLAGS         := -Wall -g -O1 -fsanitize=address
-# LDFLAGS        := -fsanitize=address 
+# CFLAGS and LDFLAGS for below to debug memory access issues
+ifdef DEBUG
+CFLAGS := -Wall -g -O1 -fsanitize=address
+LDFLAGS := -fsanitize=address 
+endif
 
 CMD_SOURCES    := $(wildcard cmd/*.c)
 CMD_OBJECTS    := $(patsubst %.c,$(BUILD_DIR)/%.o,$(CMD_SOURCES))
@@ -48,6 +50,10 @@ DIST_BASE := $(DIST_DIR)/$(DIST_NAME)
 all: $(LIB) $(CMD)
 
 dist: $(DIST_ZIP)
+
+debug: 
+	@$(MAKE) DEBUG=1 all
+
 
 
 SIMPLE_BUILD_DIR      := simple
@@ -83,6 +89,9 @@ $(SIMPLE_BUILD_DIR)/%.o: %.c $(SIMPLE_HEADERS)
 
 clean-simple:
 	rm -rf $(SIMPLE_BUILD_DIR)
+
+debug-simple:
+	@$(MAKE) DEBUG=1 simple
 
 # Stop GNU Make from removing object files resulting from chains
 # of implicit rules.

--- a/cmd/e3db.c
+++ b/cmd/e3db.c
@@ -337,10 +337,7 @@ int cmdWrite(int argc, char **argv)
 		free(configLocation);
 	}
 	E3DB_Client_Delete(client);
-
-	// there is mixing going on causing issues with these
 	E3DB_FreeRecordMeta(record->meta);
-
 	cJSON_Delete(record->data);
 	free(record->rec_sig);
 	free(record);

--- a/examples/Example.md
+++ b/examples/Example.md
@@ -13,6 +13,30 @@ git clone https://github.com/tozny/e3db-core
 make all
 ```
 
+#### Debug Build
+
+For a debug build with Address Sanitizer enabled:
+
+```bash
+make debug
+```
+
+The debug build uses Address Sanitizer, a fast memory error detector. It's useful for detecting memory access issues in the code, such as buffer overflows, use-after-free, and memory leaks.
+
+### How to Clean and Build
+
+To clean and build the project:
+
+```bash
+make clean all
+```
+
+For a clean debug build:
+
+```bash
+make clean debug
+```
+
 ## How to Run
 
 To run the following library
@@ -63,7 +87,9 @@ Read record takes a space separated list of record ids to fetch
 
 # Example Simple Program
 
-Prequesite: Must have a Tozny Client Configuration File Located @ ~/.tozny/e3db.json 
+### Prerequisite
+
+Must have a Tozny Client Configuration File Located @ `~/.tozny/e3db.json`.
 
 ## How to Build
 
@@ -72,6 +98,26 @@ To build a small example project
 ```bash
 git clone https://github.com/tozny/e3db-core
 make simple
+```
+
+For a debug build of the simple project with Address Sanitizer enabled:
+
+```bash
+make debug-simple
+```
+
+### How to Clean and Build Simple Project
+
+To clean and build the simple project:
+
+```bash
+make clean simple
+```
+
+For a clean debug build of the simple project:
+
+```bash
+make clean debug-simple
 ```
 
 ## How to Run

--- a/src/e3db_base64.c
+++ b/src/e3db_base64.c
@@ -16,7 +16,6 @@
 #include "cdecode.h"
 #include "e3db_mem.h"
 
-
 sds base64_encode(const char *s)
 {
 	BIO *bio, *b64;
@@ -34,7 +33,7 @@ sds base64_encode(const char *s)
 	long len = BIO_get_mem_data(bio, &buf);
 	char *null_terminated_buffer = (char *)xmalloc(len + 1); // one extra byte for null terminator
 	memcpy(null_terminated_buffer, buf, len);
-	
+
 	result = sdsnew(null_terminated_buffer);
 
 	BIO_free_all(bio);
@@ -79,7 +78,6 @@ sds base64_encodeUrl(const char *s)
 	BIO_write(bio, s, strlen(s));
 	BIO_flush(bio);
 
-
 	long len = BIO_get_mem_data(bio, &buf);
 	char *null_terminated_buffer = (char *)xmalloc(len + 1); // one extra byte for null terminator
 	memcpy(null_terminated_buffer, buf, len);
@@ -91,12 +89,17 @@ sds base64_encodeUrl(const char *s)
 
 	int result_len = sdslen(result);
 	for (int i = 0; i < result_len; i++)
-  {
-      switch (result[i]) {
-          case '/': result[i] = '_'; break;
-          case '+': result[i] = '-'; break;
-      }
-  }
+	{
+		switch (result[i])
+		{
+		case '/':
+			result[i] = '_';
+			break;
+		case '+':
+			result[i] = '-';
+			break;
+		}
+	}
 
 	// Remove padding characters '='
 	int padding = 0;
@@ -140,10 +143,15 @@ sds base64_encodeUrl2(const char *s, size_t size)
 
 	for (int i = 0; i < size; i++)
 	{
-    	switch (result[i]) {
-        	case '/': result[i] = '_'; break;
-        	case '+': result[i] = '-'; break;
-    	}
+		switch (result[i])
+		{
+		case '/':
+			result[i] = '_';
+			break;
+		case '+':
+			result[i] = '-';
+			break;
+		}
 	}
 
 	return result;
@@ -153,31 +161,41 @@ unsigned char *base64_decode(const char *base64)
 {
 	int len = strlen(base64);
 	unsigned char *input = (unsigned char *)xmalloc(len + 1);
-	 if (!input) {
-				fprintf(stderr, "Error: Failed to allocate memory for 'input'.\n");
-        return NULL;
-    }
+	if (!input)
+	{
+		fprintf(stderr, "Error: Failed to allocate memory for 'input'.\n");
+		return NULL;
+	}
 	// Remove double quotes, replace url encoded chars _ with / and - with +.
 	int count = 0;
 	for (int i = 0; i < len; i++)
-  {
-      switch (base64[i]) {
-          case '_': input[count++] = '/'; break;
-          case '-': input[count++] = '+'; break;
-          case '"': break;
-          default: input[count++] = base64[i];
-      }
-  }
+	{
+		switch (base64[i])
+		{
+		case '_':
+			input[count++] = '/';
+			break;
+		case '-':
+			input[count++] = '+';
+			break;
+		case '"':
+			break;
+		default:
+			input[count++] = base64[i];
+		}
+	}
 	unsigned char *new_input = xrealloc(input, count + 1);
-  if (!new_input) {
-			fprintf(stderr, "Error: Failed to reallocate memory for 'input'.\n");
-      free(input);
-      return NULL;
-  }
-  input = new_input;
+	if (!new_input)
+	{
+		fprintf(stderr, "Error: Failed to reallocate memory for 'input'.\n");
+		free(input);
+		return NULL;
+	}
+	input = new_input;
 	/* set up a destination buffer large enough to hold the encoded data */
 	unsigned char *output = (unsigned char *)xmalloc(count + 1);
-	if (!output) {
+	if (!output)
+	{
 		fprintf(stderr, "Error: Failed to allocate memory for 'output'.\n");
 		free(input);
 		return NULL;
@@ -202,56 +220,65 @@ unsigned char *base64_decode(const char *base64)
 
 unsigned char *base64_decode_with_count(const char *base64, int *cnt)
 {
-    int len = strlen(base64);
-    unsigned char *input = (unsigned char *)xmalloc(len + 1);
-    if (!input) {
-        fprintf(stderr, "Error: Failed to allocate memory for 'input'.\n");
-        return NULL;
-    }
+	int len = strlen(base64);
+	unsigned char *input = (unsigned char *)xmalloc(len + 1);
+	if (!input)
+	{
+		fprintf(stderr, "Error: Failed to allocate memory for 'input'.\n");
+		return NULL;
+	}
 
-    // Remove double quotes, replace url encoded chars _ with / and - with +.
-    int count = 0;
-    for (int i = 0; i < len; i++)
-    {
-        switch (base64[i]) {
-            case '_': input[count++] = '/'; break;
-            case '-': input[count++] = '+'; break;
-            case '"': break;
-            default: input[count++] = base64[i];
-        }
-    }
+	// Remove double quotes, replace url encoded chars _ with / and - with +.
+	int count = 0;
+	for (int i = 0; i < len; i++)
+	{
+		switch (base64[i])
+		{
+		case '_':
+			input[count++] = '/';
+			break;
+		case '-':
+			input[count++] = '+';
+			break;
+		case '"':
+			break;
+		default:
+			input[count++] = base64[i];
+		}
+	}
 
-    unsigned char *new_input = xrealloc(input, count + 1);
-    if (!new_input) {
-        fprintf(stderr, "Error: Failed to reallocate memory for 'input'.\n");
-        free(input);
-        return NULL;
-    }
-    input = new_input;
+	unsigned char *new_input = xrealloc(input, count + 1);
+	if (!new_input)
+	{
+		fprintf(stderr, "Error: Failed to reallocate memory for 'input'.\n");
+		free(input);
+		return NULL;
+	}
+	input = new_input;
 
-    /* set up a destination buffer large enough to hold the encoded data */
-    unsigned char *output = (unsigned char *)xmalloc(count + 1);
-    if (!output) {
-        fprintf(stderr, "Error: Failed to allocate memory for 'output'.\n");
-        free(input);
-        return NULL;
-    }
+	/* set up a destination buffer large enough to hold the encoded data */
+	unsigned char *output = (unsigned char *)xmalloc(count + 1);
+	if (!output)
+	{
+		fprintf(stderr, "Error: Failed to allocate memory for 'output'.\n");
+		free(input);
+		return NULL;
+	}
 
-    /* keep track of our decoded position */
-    /* store the number of bytes decoded by a single call */
-    *cnt = 0;
-    /* we need a decoder state */
-    base64_decodestate s;
+	/* keep track of our decoded position */
+	/* store the number of bytes decoded by a single call */
+	*cnt = 0;
+	/* we need a decoder state */
+	base64_decodestate s;
 
-    /*---------- START DECODING ----------*/
-    /* initialise the decoder state */
-    base64_init_decodestate(&s);
-    /* decode the input data */
-    *cnt = base64_decode_block((char *)input, count, (char *)output, &s);
-    /* note: there is no base64_decode_blockend! */
-    /*---------- STOP DECODING  ----------*/
+	/*---------- START DECODING ----------*/
+	/* initialise the decoder state */
+	base64_init_decodestate(&s);
+	/* decode the input data */
+	*cnt = base64_decode_block((char *)input, count, (char *)output, &s);
+	/* note: there is no base64_decode_blockend! */
+	/*---------- STOP DECODING  ----------*/
 
-    free(input);
-    return output;
+	free(input);
+	return output;
 }
-

--- a/src/e3db_base64.h
+++ b/src/e3db_base64.h
@@ -26,7 +26,7 @@ extern "C"
 	 *
 	 * TODO: How do we handle decode errors? */
 	unsigned char *base64_decode(const char *s);
-	unsigned char *base64_decode2(const char *s, int *count);
+	unsigned char *base64_decode_with_count(const char *s, int *count);
 
 #ifdef __cplusplus
 }

--- a/src/e3db_core.c
+++ b/src/e3db_core.c
@@ -1717,10 +1717,9 @@ const char *SignDocumentWithPrivateKey(char *document, char *privateSigningKey)
   crypto_sign_detached(sig, NULL, (const unsigned char *)document, strlen(document), decodedPrivateSigningKey);
   free(decodedPrivateSigningKey);
 
-  // Add Null terminator
+  // Add null terminator using xmalloc
   unsigned char *signedDocument = (unsigned char *)xmalloc(crypto_sign_BYTES + 1);
   memcpy(signedDocument, sig, crypto_sign_BYTES);
-  signedDocument[crypto_sign_BYTES] = '\0';
 
   char *result = base64_encodeUrl((char *)signedDocument);
   free(signedDocument);

--- a/src/e3db_core.c
+++ b/src/e3db_core.c
@@ -1197,7 +1197,7 @@ const char *E3DB_EAK_DecryptEAK(char *eak, char *pubKey, char *privKey)
     goto cleanup;
   }
   size_t eakLength = strlen(eak);
-  eak_copy = (unsigned char *)xmalloc(eakLength * sizeof(char) + 1);
+  eak_copy = (unsigned char *)xmalloc(eakLength + 1);
   strcpy((char *)eak_copy, eak);
   int i = 0;
   char *p = strtok((char *)eak_copy, ".");
@@ -1254,7 +1254,7 @@ cleanup:
 const char *E3DB_RecordFieldIterator_DecryptValue(unsigned char *edata, unsigned char *ak)
 {
   size_t edataLength = strlen((char *)edata);
-  unsigned char *edata_copy = (unsigned char *)xmalloc(edataLength * sizeof(char) + 1);
+  unsigned char *edata_copy = (unsigned char *)xmalloc(edataLength + 1);
   strcpy((char *)edata_copy, (char *)edata);
   int i = 0;
   char *p = strtok((char *)edata_copy, ".");
@@ -1267,12 +1267,12 @@ const char *E3DB_RecordFieldIterator_DecryptValue(unsigned char *edata, unsigned
   }
 
   int decodedDataKeyLength = 0;
-  unsigned char *decodedDataKey = base64_decode2(array[0], &decodedDataKeyLength);
+  unsigned char *decodedDataKey = base64_decode_with_count(array[0], &decodedDataKeyLength);
   int decodedDataKeyNonceLength = 0;
-  unsigned char *decodedDataKeyNonce = base64_decode2(array[1], &decodedDataKeyNonceLength);
+  unsigned char *decodedDataKeyNonce = base64_decode_with_count(array[1], &decodedDataKeyNonceLength);
 
   int decodedDataLength = 0;
-  unsigned char *decodedData = base64_decode2(array[2], &decodedDataLength);
+  unsigned char *decodedData = base64_decode_with_count(array[2], &decodedDataLength);
   unsigned char *decodedDataNonce = base64_decode(array[3]);
 
   unsigned char *dk = (unsigned char *)xmalloc(32);
@@ -1718,9 +1718,9 @@ const char *SignDocumentWithPrivateKey(char *document, char *privateSigningKey)
   free(decodedPrivateSigningKey);
 
   // Add Null terminator
-  unsigned char *signedDocument = (unsigned char *)xmalloc(crypto_sign_BYTES * sizeof(char) + 1);
+  unsigned char *signedDocument = (unsigned char *)xmalloc(crypto_sign_BYTES + 1);
   memcpy(signedDocument, sig, crypto_sign_BYTES);
-  signedDocument[crypto_sign_BYTES * sizeof(char)] = '\0';
+  signedDocument[crypto_sign_BYTES] = '\0';
 
   char *result = base64_encodeUrl((char *)signedDocument);
   free(signedDocument);

--- a/src/e3db_core.h
+++ b/src/e3db_core.h
@@ -146,7 +146,7 @@ extern "C"
     typedef struct _E3DB_EAK E3DB_EAK;
 
     // Delete record objects
-    void E3DB_CleanupRecords(E3DB_Record *records, int count)
+    void E3DB_CleanupRecords(E3DB_Record *records, int count);
 
     // TODO: Setters
 

--- a/src/e3db_core.h
+++ b/src/e3db_core.h
@@ -145,7 +145,9 @@ extern "C"
 
     typedef struct _E3DB_EAK E3DB_EAK;
 
-    // TODO: Create and delete record meta objects.
+    // Delete record objects
+    void E3DB_CleanupRecords(E3DB_Record *records, int count)
+
     // TODO: Setters
 
     const char *E3DB_RecordMeta_GetRecordId(E3DB_RecordMeta *meta);
@@ -157,6 +159,10 @@ extern "C"
     const char *E3DB_RecordMeta_GeLastModified(E3DB_RecordMeta *meta);
 
     cJSON *E3DB_RecordMeta_GetPlain(E3DB_RecordMeta *meta);
+
+    void E3DB_FreeRecordMeta(E3DB_RecordMeta *meta);
+
+
     const char *E3DB_EAK_GetEAK(E3DB_EAK *eak);
     const char *E3DB_EAK_GetAuthPubKey(E3DB_EAK *eak);
     const char *E3DB_EAK_DecryptEAK(char *eak, char *pubKey, char *privKey);
@@ -165,7 +171,8 @@ extern "C"
     typedef struct _E3DB_Legacy_Record E3DB_Legacy_Record;
     typedef struct _E3DB_RecordFieldIterator E3DB_RecordFieldIterator;
 
-    // TODO: Create and delete record objects
+
+
     // TODO: Setters
     // TODO: Consider an adaptor to JSON?
 


### PR DESCRIPTION
### Description
- removed `sizeof(char*)
- refactored base64 functions
- removed commented code
- added debug mode (address sanitizer) to makefile for sdk + simple sample program
- use xmalloc to simplify null termination

### Risks
none listed

### Validation
Tested for memory leaks and memory access errors. Write, Write with existing type, and Read

### Issue
csdk update

### Operating System
Apple Intel 
