### PR TITLE
experiment on header_text malloc

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -54,3 +54,10 @@ else()
     # Default library search path
     link_directories(${DEFAULT_LIBRARY_DIR})
 endif()
+
+
+
+# Enable Address Sanitizer
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address")

--- a/examples/Example.md
+++ b/examples/Example.md
@@ -228,7 +228,7 @@ To run the following example project from the top level directory
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake ..  # for debug: cmake -DCMAKE_BUILD_TYPE=Debug .. 
 make
 ./examples/simple
 ```

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,12 +1,12 @@
 {
+  "private_signing_key": "oiV-Va1CEeKkm1NQ6CbsR567fGDqZ0LdEFJBdXd_RCY3AyjBm65FC2gEJ5vty6dErvnlHyZ7v8KXh6nZS_qZtQ",
+  "public_signing_key": "NwMowZuuRQtoBCeb7cunRK755R8me7_Cl4ep2Uv6mbU",
+  "private_key": "giBAMljcVkbUAy8eesSOYdQZhpLY7xGfIy7VoxeB-qM",
+  "api_secret": "f4e1ad7812c0fdf28a840b7f8a5f50e2d66094e4a27ed51394c9a6ee2224ed26",
+  "client_id": "1b2fd595-ce1a-4682-8946-e093c6cc2514",
+  "public_key": "6izquLuFH-yfNh3AEy_8pkhEwA_HdxpEHdrXuf-nu0g",
   "version": "2",
-  "public_signing_key": "AA67Ys3is_kCYB9zHOGJKfxJe4-v-tFgqCGJT-IfIdY",
-  "private_signing_key": "mcricc2i0ClZDTQgwzQ2CYNZmvqpkWbCGX6W8vQ4yJcADrtizeKz-QJgH3Mc4Ykp_El7j6_60WCoIYlP4h8h1g",
-  "client_id": "60bc2caf-cac5-40ac-9a37-9757a9c9c560",
-  "api_key_id": "b54d6c920a53e982c53837d4ebf7df7440716539611f0f04fde3dd57d23325e3",
-  "api_secret": "23955d5424ade4fc781c2c51f0b32957f4aaae8c870c6d43ff4184e93cb45702",
-  "public_key": "GtrMKelnTk4Cl7Frx_vARfGoTTtoePUmVs-NGi8KckM",
-  "private_key": "M5njexa1_2Rgk-A-GenvrNMW5XHB70RTOzbHK-bOrcA",
+  "api_key_id": "a0dfb653099bf97e09200d958a3d1673b00eca8f4e44567bdf6b14a285ecd77a",
   "api_url": "https://api.e3db.com",
   "client_email": ""
 }

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,12 +1,12 @@
 {
-  "private_signing_key": "oiV-Va1CEeKkm1NQ6CbsR567fGDqZ0LdEFJBdXd_RCY3AyjBm65FC2gEJ5vty6dErvnlHyZ7v8KXh6nZS_qZtQ",
-  "public_signing_key": "NwMowZuuRQtoBCeb7cunRK755R8me7_Cl4ep2Uv6mbU",
-  "private_key": "giBAMljcVkbUAy8eesSOYdQZhpLY7xGfIy7VoxeB-qM",
-  "api_secret": "f4e1ad7812c0fdf28a840b7f8a5f50e2d66094e4a27ed51394c9a6ee2224ed26",
-  "client_id": "1b2fd595-ce1a-4682-8946-e093c6cc2514",
-  "public_key": "6izquLuFH-yfNh3AEy_8pkhEwA_HdxpEHdrXuf-nu0g",
   "version": "2",
-  "api_key_id": "a0dfb653099bf97e09200d958a3d1673b00eca8f4e44567bdf6b14a285ecd77a",
+  "public_signing_key": "AA67Ys3is_kCYB9zHOGJKfxJe4-v-tFgqCGJT-IfIdY",
+  "private_signing_key": "mcricc2i0ClZDTQgwzQ2CYNZmvqpkWbCGX6W8vQ4yJcADrtizeKz-QJgH3Mc4Ykp_El7j6_60WCoIYlP4h8h1g",
+  "client_id": "60bc2caf-cac5-40ac-9a37-9757a9c9c560",
+  "api_key_id": "b54d6c920a53e982c53837d4ebf7df7440716539611f0f04fde3dd57d23325e3",
+  "api_secret": "23955d5424ade4fc781c2c51f0b32957f4aaae8c870c6d43ff4184e93cb45702",
+  "public_key": "GtrMKelnTk4Cl7Frx_vARfGoTTtoePUmVs-NGi8KckM",
+  "private_key": "M5njexa1_2Rgk-A-GenvrNMW5XHB70RTOzbHK-bOrcA",
   "api_url": "https://api.e3db.com",
   "client_email": ""
 }

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -415,13 +415,17 @@ int mbedtls_run_op_with_expected_response_code(E3DB_Op *op, long expected_respon
 			}
 			while (header != NULL)
 			{
-				char *header_text = (char *)xmalloc(strlen(E3DB_HttpHeader_GetName(header)) + strlen(E3DB_HttpHeader_GetValue(header)) + 3);
+				// char *header_text = (char *)xmalloc(strlen(E3DB_HttpHeader_GetName(header)) + strlen(E3DB_HttpHeader_GetValue(header)) + 3);
+				// 4 for null char
+				char *header_text = (char *)xmalloc(strlen(E3DB_HttpHeader_GetName(header)) + strlen(E3DB_HttpHeader_GetValue(header)) + 4);
 				if (header_text == NULL)
 				{
 					fprintf(stderr, "Memory allocation error.\n");
 					exit(EXIT_FAILURE);
 				}
-				sprintf(header_text, "%s: %s\r\n", E3DB_HttpHeader_GetName(header), E3DB_HttpHeader_GetValue(header));
+				// sprintf(header_text, "%s: %s\r\n", E3DB_HttpHeader_GetName(header), E3DB_HttpHeader_GetValue(header));
+				int written = snprintf(header_text, strlen(E3DB_HttpHeader_GetName(header)) + strlen(E3DB_HttpHeader_GetValue(header)) + 4, "%s: %s\r\n", E3DB_HttpHeader_GetName(header), E3DB_HttpHeader_GetValue(header));
+
 				strcat(headers_string, header_text);
 				header = E3DB_HttpHeader_GetNext(header);
 			}


### PR DESCRIPTION
char *header_text = (char *)xmalloc(strlen(E3DB_HttpHeader_GetName(header)) + strlen(E3DB_HttpHeader_GetValue(header)) + 3); allocation error 
<img width="1120" alt="Screenshot 2023-12-17 at 4 32 35 PM" src="https://github.com/tozny/e3db-core/assets/49762919/26e4dcaa-8eb3-464a-af1e-608b4ba95d41">


confirmed with address sanitizer: karthik is correct. line curl.c:424 seg faults memory allocated by line 418. I made + 3 to + 4 for null terminator on 418 and the print to snprint for 424. now i have no seg fault but: "Fatal: Error response from E3DB API: 400. Maybe my config is wrong. 


